### PR TITLE
no longer spawn extra default expie when persistence is enabled

### DIFF
--- a/Scripts/preload/SaveLoadSys.gd
+++ b/Scripts/preload/SaveLoadSys.gd
@@ -39,7 +39,9 @@ func _ready():
 	if FileAccess.file_exists(savePath):
 		data = loadjson(savePath)
 		var templateData = loadjson(template)
-		fixMissing(data, templateData)
+		fixMissing(data, templateData) 
+		# template does not include any expies so if persistance is enabled, we don't spawn the default.
+		# below adds a single expie if there are none defined in save.json
 		if data["save"]["expies"] == {}: data["save"]["expies"] = {"Default": 1} # force a default expie to spawn if no expie data on load. avoids crash
 
 	else:

--- a/Scripts/singletons/SaveTemplate.json
+++ b/Scripts/singletons/SaveTemplate.json
@@ -9,7 +9,7 @@
 		"nickname": "",
 		"firstime": 0,
 		"interactions": false,
-		"expies": {"Default": 1}
+		"expies": {}
 	},
 	"everPresentAcrossSaves": {
 		"PetsKilled": 0.0


### PR DESCRIPTION
Fixed #22
 
When loading from persistance data (save.json), if there is no "Default" expie in the persistance data, a new one will be spawned. This happens because the call to fixMissing() in SaveLoadSys.gd line 42 reads from the saveTemplate.json, compares it to save.json, notices there is no tag for the default expie, and re-adds it.
The fix removes the default expie from saveTemplate.json; if for whatever reason save.json has no expies, then SaveLoadSys.gd line 45 adds one.