### PR TITLE
Fix click-through interaction on XWayland

### DIFF
--- a/Scripts/impo/dragExp.gd
+++ b/Scripts/impo/dragExp.gd
@@ -17,20 +17,39 @@ var _dragged_body: RigidBody2D
 var _dragger: StaticBody2D
 var _joint: PinJoint2D
 
+var _use_x11_input_regions: bool = false
+var _x11_region_bodies: Array[RigidBody2D] = []
+var _x11_region_ids: Array[int] = []
+
+# Small padding
+const X11_INPUT_MARGIN := 3.0
+const X11_INPUT_FALLBACK_HALF_SIZE := 24.0
+
 func _ready() -> void:
 	if not rigid_bodies_container:
 		push_error("there is no parent rigid body")
 		return
 
+	_use_x11_input_regions = TransparentWindow.UsesInputRegions()
+
 	#pass through every limb, then apply the signals
 	for child in rigid_bodies_container.get_children():
 		if child is RigidBody2D:
+			if _use_x11_input_regions:
+				var region_id := child.get_instance_id()
+				_x11_region_bodies.append(child)
+				_x11_region_ids.append(region_id)
+				child.tree_exiting.connect(_on_body_part_tree_exiting.bind(child, region_id))
+
 			child.input_pickable = true
 			child.mouse_entered.connect(_on_body_part_entered.bind(child))
 			child.mouse_exited.connect(_on_body_part_exited.bind(child))
 			child.input_event.connect(_on_body_part_input.bind(child))
 
 func _process(_delta: float) -> void:
+	if _use_x11_input_regions:
+		_update_x11_input_regions()
+
 	#dragging active state
 	if _dragging:
 		var mouse_pos := rigid_bodies_container.get_global_mouse_position()
@@ -43,14 +62,111 @@ func _process(_delta: float) -> void:
 			_stopDrag()
 			return
 
-	# check our cursor pos if we're hovering in transparent space
-	# since we have click through we need this else the cursor
-	# will never register as entering a limb
-	elif GlobalVariable.clickZoneSum <= 0:
-		_isMouseOver()
-	#if we are hovering, we have to make sure the cursor didn't slip off the expie
-	else:
-		_validateHoverState()
+	elif not _use_x11_input_regions:
+		# check our cursor pos if we're hovering in transparent space
+		# since we have click through we need this else the cursor
+		# will never register as entering a limb
+		if GlobalVariable.clickZoneSum <= 0:
+			_isMouseOver()
+		#if we are hovering, we have to make sure the cursor didn't slip off the expie
+		else:
+			_validateHoverState()
+
+func _update_x11_input_regions() -> void:
+	for body in _x11_region_bodies:
+		if not is_instance_valid(body):
+			continue
+
+		TransparentWindow.SetInputRect(
+			body.get_instance_id(),
+			_get_body_input_rect(body),
+			body.is_visible_in_tree()
+		)
+
+func _get_body_input_rect(body: RigidBody2D) -> Rect2:
+	var result := Rect2()
+	var found_shape := false
+
+	for child in body.get_children():
+		if not (child is CollisionShape2D):
+			continue
+
+		var collision := child as CollisionShape2D
+		if collision.disabled or collision.shape == null:
+			continue
+
+		var local_rect := _shape_local_rect(collision.shape)
+		if not local_rect.has_area():
+			continue
+
+		var shape_rect := collision.global_transform * local_rect
+		if found_shape:
+			result = result.merge(shape_rect)
+		else:
+			result = shape_rect
+			found_shape = true
+
+	if found_shape:
+		return result.grow(X11_INPUT_MARGIN)
+
+	var found_visible_sprite := false
+	for child in body.get_children():
+		if child is Sprite2D and child.is_visible_in_tree():
+			var limb_sprite := child as Sprite2D
+			if limb_sprite.texture == null:
+				continue
+
+			var sprite_rect := limb_sprite.global_transform * limb_sprite.get_rect()
+			if found_visible_sprite:
+				result = result.merge(sprite_rect)
+			else:
+				result = sprite_rect
+				found_visible_sprite = true
+
+	if found_visible_sprite:
+		return result.grow(X11_INPUT_MARGIN)
+
+	var half_size := Vector2(X11_INPUT_FALLBACK_HALF_SIZE, X11_INPUT_FALLBACK_HALF_SIZE)
+	return Rect2(body.global_position - half_size, half_size * 2.0)
+
+func _shape_local_rect(shape: Shape2D) -> Rect2:
+	if shape is RectangleShape2D:
+		var rect_shape := shape as RectangleShape2D
+		return Rect2(-rect_shape.size * 0.5, rect_shape.size)
+
+	if shape is CircleShape2D:
+		var circle := shape as CircleShape2D
+		var size := Vector2.ONE * circle.radius * 2.0
+		return Rect2(-size * 0.5, size)
+
+	if shape is CapsuleShape2D:
+		var capsule := shape as CapsuleShape2D
+		var size := Vector2(capsule.radius * 2.0, capsule.height)
+		return Rect2(-size * 0.5, size)
+
+	if shape is ConvexPolygonShape2D:
+		var polygon := shape as ConvexPolygonShape2D
+		if polygon.points.is_empty():
+			return Rect2()
+		var rect := Rect2(polygon.points[0], Vector2.ZERO)
+		for point in polygon.points:
+			rect = rect.expand(point)
+		return rect
+
+	return Rect2()
+
+func _on_body_part_tree_exiting(body: RigidBody2D, region_id: int) -> void:
+	TransparentWindow.RemoveInputRect(region_id)
+	_on_body_part_exited(body)
+
+func _exit_tree() -> void:
+	for region_id in _x11_region_ids:
+		TransparentWindow.RemoveInputRect(region_id)
+
+	if _is_contributing:
+		_is_contributing = false
+		GlobalVariable.clickZoneSum -= 1
+		TransparentWindow.SetClickThrough(GlobalVariable.clickZoneSum <= 0)
 
 ##Function that checks if the mouse is currently hovering over rigidbodies.
 func _isMouseOver() -> void:

--- a/Scripts/impo/dragObj.gd
+++ b/Scripts/impo/dragObj.gd
@@ -17,6 +17,12 @@ var _dragging := false
 var _dragger: StaticBody2D
 var _joint: DampedSpringJoint2D
 
+var _use_x11_input_regions := false
+var _input_region_id: int = 0
+var _drag_capture_region_id: int = 0
+
+const X11_INPUT_MARGIN := 3.0
+
 
 func _ready() -> void:
 	var detector := get_parent().find_child("Detector")
@@ -26,9 +32,33 @@ func _ready() -> void:
 		if gbData.devMode:
 			print("found detector")
 
+	_use_x11_input_regions = TransparentWindow.UsesInputRegions()
+
+	if _use_x11_input_regions and _foundDect:
+		_input_region_id = _dect.get_instance_id()
+		_drag_capture_region_id = get_instance_id()
+		_dect.input_pickable = true
+		_dect.mouse_entered.connect(_onEnter)
+		_dect.mouse_exited.connect(_onExit)
+		_dect.input_event.connect(_on_detector_input)
+
 
 func _process(_delta: float) -> void:
 	if not _foundDect or not _dect:
+		return
+
+	if _use_x11_input_regions:
+		_update_x11_input_regions()
+
+		if _dragging:
+			var mouse_pos := _dect.get_global_mouse_position()
+			if _dragger:
+				_dragger.global_position = mouse_pos
+
+			if not Input.is_action_pressed("click"):
+				_stopDrag()
+
+		_update_outline()
 		return
 
 	var mousePos := _dect.get_global_mouse_position()
@@ -52,10 +82,109 @@ func _process(_delta: float) -> void:
 	if _hovering and not _dragging and Input.is_action_just_pressed("click"):
 		_startDrag(mousePos)
 
+	_update_outline()
 
+
+func _update_outline() -> void:
 	var targetLine := float(outlineWidth) if (_hovering or _dragging) else 0.0
 	_currLine = lerp(_currLine, targetLine, 0.5)
 	#sprite.material.set_shader_parameter("thickness", _currLine)
+
+
+func _update_x11_input_regions() -> void:
+	TransparentWindow.SetInputRect(
+		_input_region_id,
+		_get_x11_input_rect(),
+		get_parent().is_visible_in_tree()
+	)
+
+	TransparentWindow.SetInputRect(
+		_drag_capture_region_id,
+		get_viewport().get_visible_rect(),
+		_dragging
+	)
+
+
+func _get_x11_input_rect() -> Rect2:
+	var result := Rect2()
+	var found_shape := false
+
+	for child in _dect.get_children():
+		if not (child is CollisionShape2D):
+			continue
+
+		var collision := child as CollisionShape2D
+		if collision.disabled or collision.shape == null:
+			continue
+
+		var local_rect := _shape_local_rect(collision.shape)
+		if not local_rect.has_area():
+			continue
+
+		var shape_rect := collision.global_transform * local_rect
+		if found_shape:
+			result = result.merge(shape_rect)
+		else:
+			result = shape_rect
+			found_shape = true
+
+	if found_shape:
+		return result.grow(X11_INPUT_MARGIN)
+
+	if sprite and sprite.texture:
+		return (sprite.global_transform * sprite.get_rect()).grow(X11_INPUT_MARGIN)
+
+	return Rect2(_dect.global_position - Vector2(32, 32), Vector2(64, 64))
+
+
+func _shape_local_rect(shape: Shape2D) -> Rect2:
+	if shape is RectangleShape2D:
+		var rect_shape := shape as RectangleShape2D
+		return Rect2(-rect_shape.size * 0.5, rect_shape.size)
+
+	if shape is CircleShape2D:
+		var circle := shape as CircleShape2D
+		var size := Vector2.ONE * circle.radius * 2.0
+		return Rect2(-size * 0.5, size)
+
+	if shape is CapsuleShape2D:
+		var capsule := shape as CapsuleShape2D
+		var size := Vector2(capsule.radius * 2.0, capsule.height)
+		return Rect2(-size * 0.5, size)
+
+	if shape is ConvexPolygonShape2D:
+		var polygon := shape as ConvexPolygonShape2D
+		if polygon.points.is_empty():
+			return Rect2()
+		var rect := Rect2(polygon.points[0], Vector2.ZERO)
+		for point in polygon.points:
+			rect = rect.expand(point)
+		return rect
+
+	return Rect2()
+
+
+func _on_detector_input(_viewport: Node, event: InputEvent, _shape_idx: int) -> void:
+	if event is not InputEventMouseButton:
+		return
+
+	if event.button_index == MOUSE_BUTTON_LEFT and event.pressed and not _dragging:
+		_startDrag(_dect.get_global_mouse_position())
+
+
+func _exit_tree() -> void:
+	if _hovering:
+		_setHover(false)
+
+	if is_instance_valid(_dragger):
+		_dragger.queue_free()
+	_dragging = false
+	_dragger = null
+	_joint = null
+
+	if _use_x11_input_regions:
+		TransparentWindow.RemoveInputRect(_input_region_id)
+		TransparentWindow.RemoveInputRect(_drag_capture_region_id)
 
 
 func _isMouseOver(mousePos: Vector2) -> bool:
@@ -96,6 +225,11 @@ func _startDrag(mousePos: Vector2) -> void:
 
 func _stopDrag() -> void:
 	_dragging = false
+
+	if _use_x11_input_regions:
+		TransparentWindow.RemoveInputRect(_drag_capture_region_id)
+
+		_setHover(_isMouseOver(_dect.get_global_mouse_position()))
 
 	if _dragger:
 		_dragger.queue_free()

--- a/Scripts/impo/main.gd
+++ b/Scripts/impo/main.gd
@@ -19,8 +19,8 @@ func _ready():
 	if OS.get_name() == "Linux":
 		DisplayServer.window_set_mode(DisplayServer.WINDOW_MODE_MAXIMIZED)
 
-	if OS.get_name() == "Linux" and OS.get_environment("XDG_SESSION_TYPE").to_lower() == "wayland":
-		OS.alert("This message is popping up because you are using wayland. \n \n Most if not all features will not work due to wayland's security measures. \n\n You will have to have another x11 app running to interact with them (ex: Steam) or switch to x11\n\n Sorry! I dont know any workarounds")
+	if OS.get_name() == "Linux" and OS.get_environment("XDG_SESSION_TYPE").to_lower() == "wayland" and not TransparentWindow.UsesInputRegions():
+		OS.alert("DeskSaw could not enable its XWayland input-region workaround. Click-through interaction may not work correctly. Make sure DeskSaw is running through X11/XWayland with the XShape extension available, or use an X11 session.")
 	
 	GlobalVariable.console.connect(yeah)
 	#fix()

--- a/Scripts/nimpo/clickArea.gd
+++ b/Scripts/nimpo/clickArea.gd
@@ -17,7 +17,22 @@ class_name ClickAreaControl
 var cur: bool = false
 var contributing: bool = false
 
+var _use_x11_input_regions: bool = false
+var _input_region_id: int = 0
+
+func _ready() -> void:
+	_use_x11_input_regions = TransparentWindow.UsesInputRegions()
+	_input_region_id = get_instance_id()
+
 func _process(_delta: float) -> void:
+	if _use_x11_input_regions:
+		TransparentWindow.SetInputRect(
+			_input_region_id,
+			get_global_rect().grow(2.0),
+			enabled and is_visible_in_tree()
+		)
+		return
+
 	var mouse_pos: Vector2 = get_global_mouse_position()
 	var inside: bool = (
 		mouse_pos.x >= global_position.x and
@@ -26,6 +41,15 @@ func _process(_delta: float) -> void:
 		mouse_pos.y <= global_position.y + size.y
 	)
 	change(inside)
+
+func _exit_tree() -> void:
+	if _use_x11_input_regions:
+		TransparentWindow.RemoveInputRect(_input_region_id)
+
+	if contributing:
+		contributing = false
+		GlobalVariable.clickZoneSum -= 1
+		TransparentWindow.SetClickThrough(GlobalVariable.clickZoneSum <= 0)
 
 func change(t: bool) -> void:
 	if t == cur:

--- a/Scripts/preload/TransparentWindow.cs
+++ b/Scripts/preload/TransparentWindow.cs
@@ -4,6 +4,7 @@
 // thank you ZeadenTheBirb for adding linux support to this
 using Godot;
 using System;
+using System.Collections.Generic;
 using System.Runtime.InteropServices;
 
 public partial class TransparentWindow : Node
@@ -22,58 +23,262 @@ public partial class TransparentWindow : Node
     private const int WsExTransparent = 0x20;       // Makes the window "clickable through"
                                                     // check https://learn.microsoft.com/en-us/windows/win32/winmsg/extended-window-styles 
                                                     // This is the variable containing the window handle
+
+    [StructLayout(LayoutKind.Sequential)]
+    private struct XRectangle
+    {
+        public short X;
+        public short Y;
+        public ushort Width;
+        public ushort Height;
+    }
+
+    [DllImport("libXext.so.6", CallingConvention = CallingConvention.Cdecl)]
+    private static extern int XShapeQueryExtension(IntPtr display, out int eventBase, out int errorBase);
+
+    [DllImport("libXext.so.6", CallingConvention = CallingConvention.Cdecl)]
+    private static extern void XShapeCombineRectangles(
+        IntPtr display,
+        nuint destinationWindow,
+        int destinationKind,
+        int xOffset,
+        int yOffset,
+        [In] XRectangle[] rectangles,
+        int rectangleCount,
+        int operation,
+        int ordering);
+
+    [DllImport("libX11.so.6", CallingConvention = CallingConvention.Cdecl)]
+    private static extern int XFlush(IntPtr display);
+
+    private const int ShapeInput = 2;
+    private const int ShapeSet = 0;
+    private const int Unsorted = 0;
+
     private IntPtr _hWnd;
     //  private bool isGb;
 
     private bool _isWindows;
+    private bool _isX11;
+    private bool _xShapeAvailable;
+    private IntPtr _xDisplay = IntPtr.Zero;
+    private nuint _xWindow;
+
+    private readonly Dictionary<long, Rect2I> _inputRects = new();
+    private bool _inputRectsDirty;
+
     public override void _Ready()
     {
         _isWindows = OperatingSystem.IsWindows();
+        _isX11 = OperatingSystem.IsLinux() && DisplayServer.GetName() == "X11";
+
+        GetWindow().Transparent = true;
+        GetWindow().TransparentBg = true;
+
         if (_isWindows)
         {
             // We store the window handle
             _hWnd = (IntPtr)DisplayServer.WindowGetNativeHandle(DisplayServer.HandleType.WindowHandle, GetWindow().GetWindowId());
 
-            // We can set the properties already from here
             SetWindowLong(_hWnd, GwlExStyle, WsExLayered);
-
             SetClickThrough(true);
-            GetWindow().Transparent = true;
-            GetWindow().TransparentBg = true;
+            return;
         }
-        else
+
+        if (_isX11)
         {
-            GetWindow().Transparent = true;
-            GetWindow().TransparentBg = true;
-            GetWindow().MousePassthrough = true;
+            InitX11InputRegions();
             Engine.MaxFps = 45;
+            return;
+        }
+
+        GetWindow().MousePassthrough = true;
+        Engine.MaxFps = 45;
+    }
+
+    public override void _Process(double _delta)
+    {
+        if (UsesInputRegions() && _inputRectsDirty)
+        {
+            ApplyX11InputRegion();
         }
     }
 
-    // This function sets the property of being clickable or not, we will call this function from the mouse detection 
+    public bool UsesInputRegions()
+    {
+        return _isX11 && _xShapeAvailable;
+    }
+
+    private void InitX11InputRegions()
+    {
+        try
+        {
+            long displayHandle = DisplayServer.WindowGetNativeHandle(DisplayServer.HandleType.DisplayHandle, GetWindow().GetWindowId());
+
+            long windowHandle = DisplayServer.WindowGetNativeHandle(DisplayServer.HandleType.WindowHandle, GetWindow().GetWindowId());
+
+            _xDisplay = new IntPtr(displayHandle);
+            _xWindow = unchecked((nuint)windowHandle);
+
+            if (_xDisplay == IntPtr.Zero || _xWindow == 0)
+            {
+                GD.PushWarning("DeskSaw: Could not get X11 display/window handles. Falling back to Godot mouse passthrough.");
+                GetWindow().MousePassthrough = true;
+                return;
+            }
+
+            if (XShapeQueryExtension(_xDisplay, out _, out _) == 0)
+            {
+                GD.PushWarning("DeskSaw: XShape is not available. Falling back to Godot mouse passthrough.");
+                GetWindow().MousePassthrough = true;
+                return;
+            }
+
+            _xShapeAvailable = true;
+            GetWindow().MousePassthrough = false;
+
+            _inputRectsDirty = true;
+            ApplyX11InputRegion();
+        }
+        catch (DllNotFoundException e)
+        {
+            GD.PushWarning($"DeskSaw: X11 input-region library missing: {e.Message}");
+            GetWindow().MousePassthrough = true;
+        }
+        catch (EntryPointNotFoundException e)
+        {
+            GD.PushWarning($"DeskSaw: X11 input-region function missing: {e.Message}");
+            GetWindow().MousePassthrough = true;
+        }
+    }
+
+    public void SetInputRect(long id, Rect2 rect, bool enabled)
+    {
+        if (!UsesInputRegions())
+        {
+            return;
+        }
+
+        if (!enabled || rect.Size.X <= 0.0f || rect.Size.Y <= 0.0f)
+        {
+            RemoveInputRect(id);
+            return;
+        }
+
+        int x1 = (int)Math.Floor(rect.Position.X);
+        int y1 = (int)Math.Floor(rect.Position.Y);
+        int x2 = (int)Math.Ceiling(rect.End.X);
+        int y2 = (int)Math.Ceiling(rect.End.Y);
+
+        var pixelRect = new Rect2I(x1, y1, x2 - x1, y2 - y1);
+        if (pixelRect.Size.X <= 0 || pixelRect.Size.Y <= 0)
+        {
+            RemoveInputRect(id);
+            return;
+        }
+
+        if (_inputRects.TryGetValue(id, out Rect2I oldRect) && oldRect == pixelRect)
+        {
+            return;
+        }
+
+        _inputRects[id] = pixelRect;
+        _inputRectsDirty = true;
+    }
+
+    public void RemoveInputRect(long id)
+    {
+        if (!UsesInputRegions())
+        {
+            return;
+        }
+
+        if (_inputRects.Remove(id))
+        {
+            _inputRectsDirty = true;
+        }
+    }
+
+    private void ApplyX11InputRegion()
+    {
+        if (!UsesInputRegions() || _xDisplay == IntPtr.Zero || _xWindow == 0)
+        {
+            return;
+        }
+
+        Vector2I windowSize = GetWindow().Size;
+        int windowWidth = Math.Max(windowSize.X, 0);
+        int windowHeight = Math.Max(windowSize.Y, 0);
+
+        var rectangles = new List<XRectangle>(_inputRects.Count);
+
+        foreach (Rect2I rect in _inputRects.Values)
+        {
+            int x1 = Math.Clamp(rect.Position.X, 0, Math.Min(windowWidth, short.MaxValue));
+            int y1 = Math.Clamp(rect.Position.Y, 0, Math.Min(windowHeight, short.MaxValue));
+            int x2 = Math.Clamp(rect.End.X, 0, windowWidth);
+            int y2 = Math.Clamp(rect.End.Y, 0, windowHeight);
+
+            int width = Math.Min(x2 - x1, ushort.MaxValue);
+            int height = Math.Min(y2 - y1, ushort.MaxValue);
+            if (width <= 0 || height <= 0)
+            {
+                continue;
+            }
+
+            rectangles.Add(new XRectangle
+            {
+                X = (short)x1,
+                Y = (short)y1,
+                Width = (ushort)width,
+                Height = (ushort)height
+            });
+        }
+
+        XRectangle[] nativeRectangles = rectangles.ToArray();
+
+        XShapeCombineRectangles(
+            _xDisplay,
+            _xWindow,
+            ShapeInput,
+            0,
+            0,
+            nativeRectangles,
+            nativeRectangles.Length,
+            ShapeSet,
+            Unsorted);
+
+        XFlush(_xDisplay);
+        _inputRectsDirty = false;
+    }
+
+    // This function sets the property of being clickable or not.
     public void SetClickThrough(bool clickthrough)
     {
-        _isWindows = OperatingSystem.IsWindows();
         if (_isWindows)
         {
             if (clickthrough)
             {
-                // We set the window as layered and click-through
                 SetWindowLong(_hWnd, GwlExStyle, WsExLayered | WsExTransparent);
                 Engine.MaxFps = 45;
             }
             else
             {
-                // We only set the window as layered, so it will be clickable
                 SetWindowLong(_hWnd, GwlExStyle, WsExLayered);
                 Engine.MaxFps = 60;
             }
+
+            return;
         }
-        else
+
+        if (UsesInputRegions())
         {
-            GetWindow().MousePassthrough = clickthrough;
             Engine.MaxFps = clickthrough ? 45 : 60;
+            return;
         }
+
+        GetWindow().MousePassthrough = clickthrough;
+        Engine.MaxFps = clickthrough ? 45 : 60;
     }
 
     /* What is a layered window? 


### PR DESCRIPTION
So I saw that this was an issue when i tried this out so i decided to try and fix it and well i got it working. 
It works by defining specific input regions using the X11 Shape extension, those regions receive mouse inputs. 

This would fix #7 

I tested it locally (Bazzite / Fedora 44 with KDE Plasma Wayland) and everything seemed to work. if someone else wants to test it on a different distro that would be helpful.
I hope i didn't break anything on windows