### PR TITLE
add dialogue-per-skin feature

### DIFF
--- a/Scripts/impo/behavior.gd
+++ b/Scripts/impo/behavior.gd
@@ -24,7 +24,6 @@ im putting this here as a reminder
 @onready var detectRange = $detRadius
 @onready var statUpd = $statWatcher
 
-@onready var data = gbData.text.diaGlobal
 @onready var settings = gbData.settings
 #settings for dialoguetimer
 
@@ -173,7 +172,7 @@ func checker():
 				if !isTired:
 					sleepflag1 = false
 					if randi() % 4 == 0:
-						dialogueSys.pool = data.sleepy
+						dialogueSys.pool = dialogueSys.data.sleepy
 						dialogueSys.send()
 				isTired = true
 				currentEmotion = emotionz.tired
@@ -185,7 +184,7 @@ func checker():
 						sleepflag1 = true
 						moveSys.initswithc(moveSys.states.resting)
 						if randi() % 2 == 0:
-							dialogueSys.pool = data.reallySleepy
+							dialogueSys.pool = dialogueSys.data.reallySleepy
 							dialogueSys.send()
 
 
@@ -210,13 +209,13 @@ func checker():
 				#ungry
 			if hungerHandler.hungry < 30.0:
 				if !isHungry:
-					dialogueSys.pool = data.hungry
+					dialogueSys.pool = dialogueSys.data.hungry
 					dialogueSys.send()
 					isHungry = true
 				var r = randf_range(30.0 - hungerHandler.hungry, 40.0)
 				#print("hunger notif chance ", r)
 				if r > 38.0:
-						dialogueSys.pool = data.hungry
+						dialogueSys.pool = dialogueSys.data.hungry
 						dialogueSys.send()
 
 			#update
@@ -251,7 +250,7 @@ func shock() -> void:
 	moodSys.mood -= 2.5
 	faceSys.setEmotion("panic")
 
-	dialogueSys.pool = data.screamBIG
+	dialogueSys.pool = dialogueSys.data.screamBIG
 	dialogueSys.speedMod = 1.3
 	dialogueSys.send()
 	AudioManager.play_random(AudioManager.expie_whine)
@@ -274,7 +273,7 @@ func tempRagdoll() -> void:
 		await get_tree().create_timer(getUpTimer + randf_range(0, 5)).timeout
 		if beingDragged:
 			AudioManager.play_random(AudioManager.expie_whine)
-			dialogueSys.pool = data.beingDragged
+			dialogueSys.pool = dialogueSys.data.beingDragged
 			dialogueSys.send(10, false)
 			#fix the weird ghost collision during ragdoll
 			continue
@@ -295,12 +294,12 @@ func tempRagdoll() -> void:
 	moveSys.initswithc(moveSys.states.idle)
 	if launchflag:
 		if not pet_timer.is_stopped() and pet_count >= 5:
-			dialogueSys.pool = data.getUpPet
+			dialogueSys.pool = dialogueSys.data.getUpPet
 		else:
-			dialogueSys.pool = data.getUp
+			dialogueSys.pool = dialogueSys.data.getUp
 
 	else:
-		dialogueSys.pool = data.start
+		dialogueSys.pool = dialogueSys.data.start
 	dialogueSys.speedMod = 1.3
 	dialogueSys.send()
 	AudioManager.play_random(AudioManager.expie_whine)
@@ -317,17 +316,17 @@ func passivetalk() -> void:
 			var diaTimerMaximum: float = gbData.settings["maxDialogueTime"]
 			await get_tree().create_timer(randf_range(float(diaTimerMinimum), float(diaTimerMaximum))).timeout
 			if not beingDragged and not isSleeping and not shocked:
-				dialogueSys.pool = data.Passive
+				dialogueSys.pool = dialogueSys.data.Passive
 				match currentEmotion:
 					emotionz.normal:
-						dialogueSys.pool = data.Passive
+						dialogueSys.pool = dialogueSys.data.Passive
 					emotionz.happy:
-						dialogueSys.pool = data.HappyPassive
+						dialogueSys.pool = dialogueSys.data.HappyPassive
 					emotionz.sad:
 						#oops
-						dialogueSys.pool = data.LowPassive
+						dialogueSys.pool = dialogueSys.data.LowPassive
 						if moodSys.mood < -30.0:
-							dialogueSys.pool = data.VeryLowPassive
+							dialogueSys.pool = dialogueSys.data.VeryLowPassive
 
 
 				dialogueSys.speedMod = 1.0
@@ -361,7 +360,7 @@ func wandering() -> void:
 			await get_tree().create_timer(randi_range(4, 8)).timeout
 
 func petReject() -> void:
-	dialogueSys.pool = data.petReject
+	dialogueSys.pool = dialogueSys.data.petReject
 	dialogueSys.speedMod = 1.2
 	dialogueSys.send(2, false)
 	AudioManager.play_random(AudioManager.expie_bark, 0.25, 0, 1, true, 0.5, 'exp_pet')
@@ -406,7 +405,7 @@ func petLimb(limb: RigidBody2D):
 		tween.tween_property(sprite, "scale", Vector2(1.0, 1.0), 0.25)
 	
 	if not dialogueSys.is_dialogue_playing():
-		dialogueSys.pool = data.pet
+		dialogueSys.pool = dialogueSys.data.pet
 		dialogueSys.speedMod = 0.7
 		dialogueSys.send(2, false)
 		

--- a/Scripts/impo/dialogueManager.gd
+++ b/Scripts/impo/dialogueManager.gd
@@ -1,7 +1,7 @@
 extends Node
 class_name Dialogue
 
-@onready var data = gbData.text.diaGlobal
+var data
 @onready var dialogueTimer = $dialogueTimer
 @export var richtextlabel: RichTextLabel
 @export var textspeed: float = 0.04
@@ -25,6 +25,7 @@ var base_db: float = -10 # Set base audio level of text
 var variance_db: float = 3.0
 
 func _ready() -> void:
+	data = gbData.getDialogueForSkin(GlobalVariable.userSkinPath)
 	richtextlabel.add_theme_font_size_override("normal_font_size", gbData.settings.expieDialogueSize)
 	print("LOADED DIALOGUE KEYS: ", data.keys())
 

--- a/Scripts/impo/hunger_handler.gd
+++ b/Scripts/impo/hunger_handler.gd
@@ -52,12 +52,12 @@ func _onItemEnter(body: Node2D) -> void:
 	foodDb = true
 
 	if hungry >= 98.0:
-		dialogue.pool = gbData.text.diaGlobal.Full
+		dialogue.pool = dialogue.data.Full
 		dialogue.send()
 		awaitDB()
 		return
 	if props.tasteIfConsumable == 0:
-		dialogue.pool = gbData.text.diaGlobal.EatReject
+		dialogue.pool = dialogue.data.EatReject
 		dialogue.send()
 		awaitDB()
 		return
@@ -77,14 +77,14 @@ func awaitDB() -> void:
 	pass
 func _getTasteDialogue(taste: int) -> Array:
 	if taste <= 3:
-		return gbData.text.diaGlobal.EatBad
+		return dialogue.data.EatBad
 	elif taste <= 6:
-		return gbData.text.diaGlobal.EatOk
+		return dialogue.data.EatOk
 	else:
-		return gbData.text.diaGlobal.EatGood
+		return dialogue.data.EatGood
 
 """
-					dialogueSys.pool = data.sleepy
+					dialogueSys.pool = dialogue.data.sleepy
 					dialogueSys.send()
 					ao[sdkfopasdifpas pfasip[df pasdf p[asdp[asjdfjsdpfjasoi dfjiopasdfjiopasdfjiopasfjipasdjf[ipasjfipj]]]]]
 					"""

--- a/Scripts/preload/SaveLoadSys.gd
+++ b/Scripts/preload/SaveLoadSys.gd
@@ -13,6 +13,8 @@ var data = {}
 var text = {}
 var settings = {}
 
+var dialogueCache = {}
+
 var skinData = []
 
 var template = "res://Scripts/singletons/SaveTemplate.json"
@@ -164,7 +166,11 @@ If you want multiple skins, just rename your 'Body' folder to whatever you want 
 (however you have to keep a 'Body' folder with any skin in it for it to work!)
 If you have both a 'Body' and 'Head' folder, combine the files inside them into a new folder and drag them in here.
 
-If your skin is only on the head, try restarting the app. That usually fixes it.""")
+If your skin is only on the head, try restarting the app. That usually fixes it.
+
+If you want custom dialogue for a specific skin, just copy the 'TRANSLATION.json' file from outside the folder and paste it into skin’s folder!
+Skin with TRANSLATION.json file will use it's own dialogue instead of the default one.
+""")
 				txt.close()
 	
 	var folder_to_copy = "res://assets/Body"
@@ -212,6 +218,22 @@ func loadjson(filepath: String):
 		if gbData.devMode:
 			print("File not found: " + filepath)
 		return {}
+
+# looks for a TRANSLATION.json in the skin folder, falls back to the global one
+func getDialogueForSkin(skinPath: String):
+	if skinPath.begins_with("res:"):
+		return text.diaGlobal
+	if dialogueCache.has(skinPath):
+		return dialogueCache[skinPath]
+	var merged = text.diaGlobal.duplicate(true)
+	var skinFile = skinPath + "TRANSLATION.json"
+	if FileAccess.file_exists(skinFile):
+		var skinText = loadjson(skinFile)
+		if skinText is Dictionary and skinText.get("diaGlobal") is Dictionary:
+			for key in skinText["diaGlobal"]:
+				merged[key] = skinText["diaGlobal"][key]
+			dialogueCache[skinPath] = merged
+	return merged
 
 func savetodisk(path, dt):
 		var file = FileAccess.open(path, FileAccess.WRITE)


### PR DESCRIPTION
<img width="370" height="150" alt="Screenshot_of_sawians" src="https://github.com/user-attachments/assets/02957124-f854-4661-bfc3-c0d3a24ba38d" />
<img width="512" height="306" alt="Screenshot_of_finder" src="https://github.com/user-attachments/assets/4c9219ee-a31a-4f29-9ae8-646287411975" />

While spawning and observing the dune and expie skins, I noticed that both characters sharing the same dialogue feel a bit awkward. 
So I made a small change about dialogue system.

- If a `TRANSLATION.json` file is presented inside a specific skin's folder, Characters spawned with that skin will use dialogue lines from that file.
- Otherwise, They will default to using the base `TRANSLATION.json` file.